### PR TITLE
Update tag_and_release.yml

### DIFF
--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -3,7 +3,10 @@ on:
   push:
     branches:
       - 'main'
-
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 jobs:
   deploy-to-prod:
     runs-on: ubuntu-latest
@@ -30,10 +33,10 @@ jobs:
           custom_tag: ${{ steps.version.outputs.content }}
           tag_prefix: ""
 
-      - name: 🪽 Release
-        uses: actions/create-release@v1.1.0
+      - name: Create Release
+        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Or use your PAT
         with:
           tag_name: ${{ steps.github-tag-action.outputs.new_tag }}
           release_name: Release ${{ steps.github-tag-action.outputs.new_tag }}


### PR DESCRIPTION
## Summary by Sourcery

Update the tag_and_release GitHub Actions workflow to improve permissions, use the latest release action version, and refine step definitions.

Enhancements:
- Add explicit write permissions for contents, issues, and pull-requests to the workflow.
- Update actions/create-release action version from v1.1.0 to v1 and rename the step to "Create Release".
- Refine the GITHUB_TOKEN environment variable formatting and comment for clarity.