### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete regular expression for hostnames

### DIFF
--- a/apps/web/cypress/e2e/redirects.test.ts
+++ b/apps/web/cypress/e2e/redirects.test.ts
@@ -3,7 +3,7 @@ import { FeatureFlags } from "uniswap/src/features/gating/flags"
 describe('Redirect', () => {
   it('should redirect to /vote/create-proposal when visiting /create-proposal', () => {
     cy.visit('/create-proposal')
-    cy.url().should('match', /\/vote\.uniswapfoundation\.org/)
+    cy.location('hostname').should('eq', 'vote.uniswapfoundation.org')
   })
   it('should redirect to /not-found when visiting nonexist url', () => {
     cy.visit('/none-exist-url')


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/uniswap.app/security/code-scanning/5](https://github.com/Dargon789/uniswap.app/security/code-scanning/5)

In general, hostname regular expressions must escape literal dots (`.`) as `\.` to avoid matching any character. When asserting that a URL contains a specific host like `vote.uniswapfoundation.org`, the regex should use `vote\.uniswapfoundation\.org` rather than `vote.uniswapfoundation.org`.

For this specific file, the best minimal fix is to update the regex in `apps/web/cypress/e2e/redirects.test.ts` line 6 so that it matches the literal hostname. Since this is a JavaScript regex literal, the dot must be escaped once in the regex (`\.`), which appears as `\.` in the TypeScript source. No changes are needed to other tests, and no imports or additional methods are required. Only the single line with `cy.url().should('match', /\/vote.uniswapfoundation.org/)` needs to be adjusted to `cy.url().should('match', /\/vote\.uniswapfoundation\.org/)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Correct hostname regex in redirect test to treat dots as literals instead of wildcard characters.