### PR TITLE
Snyk fix bcd5ab340d53b38620bd2837f5952df6

### DIFF
--- a/apps/web/cypress/e2e/redirects.test.ts
+++ b/apps/web/cypress/e2e/redirects.test.ts
@@ -3,7 +3,7 @@ import { FeatureFlags } from "uniswap/src/features/gating/flags"
 describe('Redirect', () => {
   it('should redirect to /vote/create-proposal when visiting /create-proposal', () => {
     cy.visit('/create-proposal')
-    cy.url().should('match', /\/vote.uniswapfoundation.org/)
+    cy.location('hostname').should('eq', 'vote.uniswapfoundation.org')
   })
   it('should redirect to /not-found when visiting nonexist url', () => {
     cy.visit('/none-exist-url')

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -40,7 +40,7 @@
     "graphql": "16.8.1",
     "i18next": "23.10.0",
     "jsbi": "3.2.5",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "mockdate": "3.0.5",
     "no-yolo-signatures": "0.0.2",
     "react": "18.3.1",


### PR DESCRIPTION
## Summary by Sourcery

Update wallet dependency and adjust redirect test hostname assertion.

Enhancements:
- Bump lodash dependency in the wallet package to a newer patch version.

Tests:
- Refine Cypress redirect test to assert on the redirected hostname instead of using a URL regex.